### PR TITLE
Show full list of tags, not hiding the first

### DIFF
--- a/src/org/frostbite/karren/Interactions/Tags/VRChat/VRCUserSearch.java
+++ b/src/org/frostbite/karren/Interactions/Tags/VRChat/VRCUserSearch.java
@@ -123,6 +123,7 @@ public class VRCUserSearch extends Tag {
         StringBuilder builder = new StringBuilder();
 
         if(tags.size()>0) {
+            builder.append(System.lineSeparator());
             for (String tag : tags) {
                 builder.append(tag).append(System.lineSeparator());
             }


### PR DESCRIPTION
If it's this simple, it's literally one line, essentially doing this:

```
```\n
tag_1
tag_2
tag_3
etc
(close code-block)
```

before it was 
```
```tag_1
tag_2
tag_3
etc
(close code-block)
```